### PR TITLE
feat: add diff support for 'calledWith*' matchers

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -126,7 +126,30 @@
             var passed = utils.test(this, [expression]);
             var messages = getMessages(passed,
                 this._obj, action, passedSuffix, failedSuffix, shouldBeAlways, slice.call(arguments));
-            this.assert(expression, messages.affirmative, messages.negative);
+            var actual;
+            var expected;
+            if (!passed) {
+                if (sinonMethodName.indexOf("calledWith") === 0) {
+                    var lastCall = this._obj.lastCall || this._obj;
+                    actual = lastCall.args && lastCall.args;
+                    if (this._obj.callCount === 0) {
+                        actual = undefined;
+                    }
+
+                    expected = slice.call(arguments);
+                }
+            }
+
+            var enableDiff = !passed;
+
+            this.assert(
+                expression,
+                messages.affirmative,
+                messages.negative,
+                expected,
+                actual,
+                enableDiff
+            );
         };
     }
 

--- a/test/messages.js
+++ b/test/messages.js
@@ -522,6 +522,105 @@ describe("Messages", function () {
         });
     });
 
+    describe("diff support", function () {
+        it("should add actual/expected and set enableDiff to true", function () {
+            var spy = sinon.spy();
+            spy("foo1");
+
+            var err;
+
+            try {
+                expect(spy).to.have.been.calledWith("bar");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).ok;
+            expect(err).to.ownProperty("showDiff", true);
+            expect(err).to.ownProperty("actual").deep.eq(["foo1"]);
+            expect(err).to.ownProperty("expected").deep.eq(["bar"]);
+        });
+
+        it("should use lastCall args if exists", function () {
+            var spy = sinon.spy();
+            spy("foo1");
+            spy("foo2");
+
+            var err;
+
+            try {
+                expect(spy).to.have.been.calledWith("bar");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).ok;
+            expect(err).to.ownProperty("showDiff", true);
+            expect(err).to.ownProperty("actual").deep.eq(["foo2"]);
+            expect(err).to.ownProperty("expected").deep.eq(["bar"]);
+        });
+
+        it("should use args if no lastCall", function () {
+            var spy = sinon.spy();
+            spy("foo1");
+            spy("foo2");
+
+            var err;
+
+            try {
+                expect(spy.firstCall).to.have.been.calledWith("bar");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).ok;
+            expect(err).to.ownProperty("showDiff", true);
+            expect(err).to.ownProperty("actual").deep.eq(["foo1"]);
+            expect(err).to.ownProperty("expected").deep.eq(["bar"]);
+        });
+
+        it("should use undefined if no call", function () {
+            var spy = sinon.spy();
+
+            var err;
+
+            try {
+                expect(spy).to.have.been.calledWith("bar");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).ok;
+            expect(err).to.ownProperty("showDiff", true);
+            expect(err).to.ownProperty("actual").deep.eq(undefined);
+            expect(err).to.ownProperty("expected").deep.eq(["bar"]);
+        });
+
+        it("should not add actual/expected and set enableDiff to true if passes", function () {
+            var spy = sinon.spy();
+            spy("foo", "bar", "baz");
+
+            var err;
+
+            try {
+                spy.should.calledWithExactly("foo", "bar", "baz");
+            } catch (e) {
+                err = e;
+            }
+            expect(err).to.be.undefined;
+        });
+
+        it("should not add actual/expected and set enableDiff if not 'calledWith' matcher", function () {
+            var spy = sinon.spy();
+            spy("foo", "bar", "baz");
+
+            var err;
+
+            try {
+                expect(spy).to.have.been.calledTwice();
+            } catch (e) {
+                err = e;
+            }
+            expect(err).ownProperty("showDiff").eq(false);
+        });
+    });
+
     describe("when used on a non-spy/non-call", function () {
         function notSpy() {
             // Contents don't matter


### PR DESCRIPTION
allows:
```js
spy('foo1')
spy('foo2')
expect(spy).calledWith('bar')
// actual: ['foo2']
// expected: ['bar']

expect(spy.firstCall).calledWith('bar')
// actual: ['foo1']
// expected: ['bar']

expect(neverCalledSpy).calledWith('bar')
// actual: undefined
// expected: ['bar']

```

output if I let the unit tests I added fail without being caught:
![19-06-17_16:04::35](https://user-images.githubusercontent.com/14625260/59633196-f3159a80-9119-11e9-9c3c-c4460914377e.png)
![19-06-17_16:05::35](https://user-images.githubusercontent.com/14625260/59633204-f741b800-9119-11e9-8f8a-311f9ca30bd7.png)
![19-06-17_16:06::00](https://user-images.githubusercontent.com/14625260/59633211-fb6dd580-9119-11e9-84b9-13fce4f1f540.png)
